### PR TITLE
Add compression

### DIFF
--- a/src/Helpers/ZStdHelper.cs
+++ b/src/Helpers/ZStdHelper.cs
@@ -70,18 +70,12 @@ public class ZStdHelper
 
     public static void CompressFolder(string path, string output, bool recursive, Action<int>? setCount = null, Action<int>? updateCount = null)
     {
-        string[] allFiles = Directory.GetFiles(path, "*.*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
-        List<string> files = new(allFiles.Length);
-        foreach (string file in allFiles)
-        {
-            if (Path.GetExtension(file) != ".zs")
-            {
-                files.Add(file);
-            }
-        }
-        setCount?.Invoke(files.Count);
+        string[] files = Directory.EnumerateFiles(path, "*.*", recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly)
+            .Where(path => Path.GetExtension(path) != ".zs" && Path.GetFileName(path) != "ZsDic.pack")
+            .ToArray();
+        setCount?.Invoke(files.Length);
 
-        for (int i = 0; i < files.Count; i++)
+        for (int i = 0; i < files.Length; i++)
         {
             string file = files[i];
             Span<byte> data = Compress(file);

--- a/src/Helpers/ZStdHelper.cs
+++ b/src/Helpers/ZStdHelper.cs
@@ -31,6 +31,9 @@ public class ZStdHelper
         _commonCompressor.LoadDictionary(sarc["zs.zsdic"]);
         _mapCompressor.LoadDictionary(sarc["bcett.byml.zsdic"]);
         _packCompressor.LoadDictionary(sarc["pack.zsdic"]);
+        _commonCompressor.Level = 15;
+        _mapCompressor.Level = 15;
+        _packCompressor.Level = 15;
     }
 
     public static Span<byte> Decompress(string file)

--- a/src/Helpers/ZStdHelper.cs
+++ b/src/Helpers/ZStdHelper.cs
@@ -16,9 +16,9 @@ public class ZStdHelper
     private static readonly Decompressor _commonDecompressor = new();
     private static readonly Decompressor _mapDecompressor = new();
     private static readonly Decompressor _packDecompressor = new();
-    private static readonly Compressor _commonCompressor = new();
-    private static readonly Compressor _mapCompressor = new();
-    private static readonly Compressor _packCompressor = new();
+    private static readonly Compressor _commonCompressor = new(15);
+    private static readonly Compressor _mapCompressor = new(15);
+    private static readonly Compressor _packCompressor = new(15);
 
     static ZStdHelper()
     {
@@ -28,12 +28,10 @@ public class ZStdHelper
         _commonDecompressor.LoadDictionary(sarc["zs.zsdic"]);
         _mapDecompressor.LoadDictionary(sarc["bcett.byml.zsdic"]);
         _packDecompressor.LoadDictionary(sarc["pack.zsdic"]);
+        
         _commonCompressor.LoadDictionary(sarc["zs.zsdic"]);
         _mapCompressor.LoadDictionary(sarc["bcett.byml.zsdic"]);
         _packCompressor.LoadDictionary(sarc["pack.zsdic"]);
-        _commonCompressor.Level = 15;
-        _mapCompressor.Level = 15;
-        _packCompressor.Level = 15;
     }
 
     public static Span<byte> Decompress(string file)

--- a/src/ViewModels/ShellViewModel.cs
+++ b/src/ViewModels/ShellViewModel.cs
@@ -14,12 +14,15 @@ public class ShellViewModel : ReactiveObject
         get => _filePath;
         set {
             this.RaiseAndSetIfChanged(ref _filePath, value);
-            this.RaiseAndSetIfChanged(ref _canDecompress, File.Exists(value), nameof(CanDecompress));
+            this.RaiseAndSetIfChanged(ref _canDecompress, File.Exists(value) && Path.GetExtension(value) == ".zs", nameof(CanDecompress));
+            this.RaiseAndSetIfChanged(ref _canCompress, File.Exists(value) && Path.GetExtension(value) != ".zs", nameof(CanCompress));
         }
     }
 
     private bool _canDecompress = false;
     public bool CanDecompress => _canDecompress;
+    private bool _canCompress = false;
+    public bool CanCompress => _canCompress;
 
     private bool _decompressRecursive = true;
     public bool DecompressRecursive {
@@ -33,11 +36,14 @@ public class ShellViewModel : ReactiveObject
         set {
             this.RaiseAndSetIfChanged(ref _folderPath, value);
             this.RaiseAndSetIfChanged(ref _canDecompressFolder, Directory.Exists(value), nameof(CanDecompressFolder));
+            this.RaiseAndSetIfChanged(ref _canCompressFolder, Directory.Exists(value), nameof(CanCompressFolder));
         }
     }
 
     private bool _canDecompressFolder;
     public bool CanDecompressFolder => _canDecompressFolder;
+    private bool _canCompressFolder;
+    public bool CanCompressFolder => _canCompressFolder;
 
     public async Task Browse(object param)
     {
@@ -96,6 +102,46 @@ public class ShellViewModel : ReactiveObject
             await dlg.ShowAsync();
         }
     }
+    
+    public async Task Compress()
+    {
+        try
+        {
+            string outputFile = $"{Path.GetFileName(FilePath)}.zs";
+            BrowserDialog dialog = new(BrowserMode.SaveFile, "Save Compressed File", $"Zstd Compressed File:*.zs|Any File:*.*", outputFile, "save");
+            if (await dialog.ShowDialog() is string path)
+            {
+                using FileStream fs = File.Create(path);
+                fs.Write(ZStdHelper.Compress(FilePath));
+
+                ContentDialog dlg = new()
+                {
+                    Content = $"File compressed to '{path}'",
+                    DefaultButton = ContentDialogButton.Primary,
+                    PrimaryButtonText = "Close",
+                    Title = "Notice"
+                };
+
+                await dlg.ShowAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            ContentDialog dlg = new()
+            {
+                Content = new TextBox
+                {
+                    MaxHeight = 250,
+                    Text = ex.ToString(),
+                    IsReadOnly = true,
+                },
+                PrimaryButtonText = "OK",
+                Title = "Unhandled Exception"
+            };
+
+            await dlg.ShowAsync();
+        }
+    }
 
     public async Task DecompressFolder()
     {
@@ -115,6 +161,39 @@ public class ShellViewModel : ReactiveObject
 
                 await dlg.ShowAsync();
                 StopLoading();
+            }
+        }
+        catch (Exception ex) {
+            ContentDialog dlg = new() {
+                Content = new TextBox {
+                    MaxHeight = 250,
+                    Text = ex.ToString(),
+                    IsReadOnly = true,
+                },
+                PrimaryButtonText = "OK",
+                Title = "Unhandled Exception"
+            };
+
+            await dlg.ShowAsync();
+        }
+    }
+
+    public async Task CompressFolder()
+    {
+        try {
+            string outputFile = Path.GetFileNameWithoutExtension(FilePath);
+            BrowserDialog dialog = new(BrowserMode.OpenFolder, "Output Folder", "save-fld");
+            if (await dialog.ShowDialog() is string path && Directory.Exists(path)) {
+                await Task.Run(() => ZStdHelper.CompressFolder(FolderPath, path, DecompressRecursive));
+
+                ContentDialog dlg = new() {
+                    Content = $"Folder compressed to '{path}'",
+                    DefaultButton = ContentDialogButton.Primary,
+                    PrimaryButtonText = "Close",
+                    Title = "Notice"
+                };
+
+                await dlg.ShowAsync();
             }
         }
         catch (Exception ex) {

--- a/src/ViewModels/ShellViewModel.cs
+++ b/src/ViewModels/ShellViewModel.cs
@@ -183,8 +183,10 @@ public class ShellViewModel : ReactiveObject
         try {
             string outputFile = Path.GetFileNameWithoutExtension(FilePath);
             BrowserDialog dialog = new(BrowserMode.OpenFolder, "Output Folder", "save-fld");
-            if (await dialog.ShowDialog() is string path && Directory.Exists(path)) {
-                await Task.Run(() => ZStdHelper.CompressFolder(FolderPath, path, DecompressRecursive));
+            if (await dialog.ShowDialog() is string path && Directory.Exists(path))
+            {
+                StartLoading();
+                await Task.Run(() => ZStdHelper.CompressFolder(FolderPath, path, DecompressRecursive, SetCount, UpdateCount));
 
                 ContentDialog dlg = new() {
                     Content = $"Folder compressed to '{path}'",
@@ -194,6 +196,7 @@ public class ShellViewModel : ReactiveObject
                 };
 
                 await dlg.ShowAsync();
+                StopLoading();
             }
         }
         catch (Exception ex) {

--- a/src/Views/ShellView.axaml
+++ b/src/Views/ShellView.axaml
@@ -40,9 +40,14 @@
                             Content="Browse"
                             CornerRadius="0,3,3,0" />
                 </Grid>
-                <Button Command="{Binding Decompress}"
-                        Content="Decompress"
-                        IsEnabled="{Binding CanDecompress}" />
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                  <Button Command="{Binding Decompress}"
+                          Content="Decompress"
+                          IsEnabled="{Binding CanDecompress}" />
+                  <Button Command="{Binding Compress}"
+                          Content="Compress"
+                          IsEnabled="{Binding CanCompress}" />
+                </StackPanel>
                 <Border Height="1" Background="{DynamicResource ControlStrokeColorOnAccentDefault}" />
                 <Grid ColumnDefinitions="*,Auto">
                     <TextBox Name="FolderNameEntry"
@@ -61,7 +66,10 @@
                     <Button Command="{Binding DecompressFolder}"
                             Content="Decompress Folder"
                             IsEnabled="{Binding CanDecompressFolder}" />
-                    <CheckBox Content="Decompress Folder Recursively" IsChecked="{Binding DecompressRecursive}" />
+                    <Button Command="{Binding CompressFolder}"
+                            Content="Compress Folder"
+                            IsEnabled="{Binding CanCompressFolder}" />
+                    <CheckBox Content="De/Compress Folder Recursively" IsChecked="{Binding DecompressRecursive}" />
                 </StackPanel>
             </StackPanel>
             <StackPanel Grid.Row="2" Orientation="Horizontal">


### PR DESCRIPTION
CompressFolder "globs" in two steps: the actual glob and then a compilation of those results that don't end in `.zs`. I did it this way because I don't like using negative lookarounds, and this was simple enough that it's not gonna matter.

Everything else should be fine.